### PR TITLE
OrderStatus Enum Type.

### DIFF
--- a/src/enums/OrderStatusEnum.ts
+++ b/src/enums/OrderStatusEnum.ts
@@ -1,5 +1,5 @@
 export enum OrderStatus {
-  processed,
-  outForDelivery,
-  delivered,
+  processed = "processed",
+  outForDelivery = "outForDelivery",
+  delivered = "delivered",
 }


### PR DESCRIPTION
OrderStatus Enum now returns a string instead of a number.