### PR TITLE
Implement Role Management with Admin Restriction and Validation

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -30,7 +30,7 @@ class AuthController {
     }
 
     try {
-      await this.authService.register(name, email, address, password, role);
+      await this.authService.register(name, email, address, password);
       res.status(201).json({ message: "User created successfully" });
     } catch (error: any) {
       res.status(400).json({ error: error.message });

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -6,7 +6,7 @@ import { User } from "../models";
 
 @injectable()
 export class UserController {
-  constructor(@inject(UserService) private userService: UserService) {}
+  constructor(@inject(UserService) private userService: UserService) { }
 
   async createUser(req: Request, res: Response): Promise<User> {
     try {
@@ -120,6 +120,37 @@ export class UserController {
       return res
         .status(400)
         .json({ error: error.message || "An error occurred" });
+    }
+  }
+
+  // controller function to change the role of a user
+  async changeRole(req: Request, res: Response): Promise<User | null> {
+    try {
+      console.log(`Changing role of user with ID: ${req.params.id}`);
+
+      const userId = parseInt(req.params.id, 10);
+      const role = req.body.role;
+
+      console.log("Request to change role of user with ID:", userId);
+      console.log("Request body data:", role);
+
+      const updatedUser = await this.userService.changeRole(userId, role);
+      if (!updatedUser) {
+        res.status(404).json({ error: "User not found or no changes made" });
+        return null;
+      }
+
+      // remove the password from the response
+      updatedUser.password = '****************';
+
+      res.json(updatedUser);
+      return updatedUser;
+
+    } catch (error: any) {
+      console.error("Error in changeRole controller:", error);
+      res.status(400).json({ error: error.message });
+      return null; // Ensure the function completes
+
     }
   }
 }

--- a/src/data-access/UserRepository.ts
+++ b/src/data-access/UserRepository.ts
@@ -1,6 +1,7 @@
 import { User } from "../models";
 import { IUserRepository } from "./Interfaces/IUserRepository";
 import { RepositoryBase } from "./RepositoryBase";
+import { UserRoles } from "../enums/UserRolesEnum";
 
 export class UserRepository
   extends RepositoryBase<User>
@@ -55,6 +56,41 @@ export class UserRepository
   async deleteUser(id: number): Promise<boolean> {
     const deletedRows = await this.model.destroy({ where: { id } });
     return deletedRows > 0;
+  }
+
+  // function to change the role of a user
+  async changeRole(id: number, role: string): Promise<User | null> {
+
+    // check if the user exists
+    const user = await this.model.findByPk(id);
+    if (!user) {
+      console.warn(`User not found with id: ${id}`);
+      return null;
+    }
+
+    // check if the role is valid
+    if (!Object.values(UserRoles).includes(role as UserRoles)) {
+      console.warn(`Invalid role: ${role}`);
+      return null;
+    }
+
+    // check if the role is already the same
+    if (user.role === role) {
+      console.warn(`User already has role: ${role}`);
+      return user;
+    }
+    
+    // update the role of the user
+    const [affectedRows] = await this.model.update({ role }, {
+      where: { id },
+    });
+
+    if (affectedRows === 0) {
+      console.log('No rows affected, possibly due to identical data.');
+      return null;
+    }
+    const updatedUser = await this.model.findByPk(id);
+    return updatedUser;
   }
 
 

--- a/src/models/User.model.ts
+++ b/src/models/User.model.ts
@@ -41,6 +41,7 @@ export class User extends Model<User> {
   @Column({
     type: DataType.ENUM(...userRoles),
     allowNull: false,
+    defaultValue: UserRoles.user,
   })
   role!: string;
 

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -17,4 +17,6 @@ userRouter.patch("/id/:id", authAndRoleMiddleware(["admin"]), userController.upd
 userRouter.delete("/id/:id", authAndRoleMiddleware(["admin"]), userController.deleteUser.bind(userController));
 
 userRouter.patch("/password/:id", authAndRoleMiddleware(["user", "admin"]), userController.editUserPassword.bind(userController));
+
+userRouter.patch("/role/:id", authAndRoleMiddleware(["admin"]), userController.changeRole.bind(userController));
 export default userRouter;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -37,7 +37,6 @@ export default class AuthService {
         email: string,
         address: string,
         password: string,
-        role: string
     ): Promise<User> {
         const existingUser = await this.userService.getUserByEmail(email);
         if (existingUser) {
@@ -45,7 +44,7 @@ export default class AuthService {
         }
 
         const hashedPassword = await bcrypt.hash(password, 10);
-        const newUser = { name, email, password: hashedPassword, address, role };
+        const newUser = { name, email, password: hashedPassword, address, role: 'user' };
         return await this.userService.createUser(newUser);
     }
 

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -144,4 +144,16 @@ export default class UserService {
       throw new Error(`Error deleting user: ${error}`);
     }
   }
+
+
+  // Function to change the role of a user
+  async changeRole(userId: number, role: string): Promise<User | null> {
+    try {
+      
+      return await userRepository.changeRole(userId, role);
+    } catch (error: any) {
+      throw new Error(`Error changing user role: ${error.message}`);
+
+    }
+  }
 }


### PR DESCRIPTION

This pull request introduces the following enhancements to the user management system:

- **Role Management:**
  - Implemented functionality to change a user's role with strict validation.
  - Only users with the `admin` role are permitted to change another user's role.

- **Detailed Validation:**
  - Added checks to ensure the role being set is valid based on predefined roles in the `UserRoles` enum.
  - Included a check to ensure the role change only occurs if the new role is different from the current role.

- **Controller and Service Enhancements:**
  - Updated the `changeRole` method in the user service to handle role changes with the necessary validation and error handling.
  - Integrated the `changeRole` functionality into the user controller to allow role changes via a `PATCH` request.
  - Added logging to provide feedback during the role change process, helping to diagnose issues such as invalid roles or non-existent users.

- **API Endpoint:**
  - Added a new API endpoint at `PATCH /role/:id` to allow role changes, protected by an `authAndRoleMiddleware` that ensures only admins can access this functionality.

- **Testing Instructions:**
  - Use Postman or another API client to send a `PATCH` request to the `/role/:id` endpoint.
  - Ensure you include the `Authorization` header with a valid JWT token for an admin user.
  - Test with various scenarios, including valid role changes, invalid roles, and non-existent users.

- **Example Request Body:**
  ```json
  {
      "role": "admin"
  }
  ```

- **Additional Notes:**
  - Comprehensive error handling has been added to provide clear feedback for invalid operations, such as attempting to assign an invalid role or changing the role of a non-existent user.
  - This update enhances the security and flexibility of the role management system, ensuring that only authorized users can modify roles.

